### PR TITLE
Only run tests when RunTests is true or True

### DIFF
--- a/NUnit.MSBuild/NUnit.MSBuild.targets
+++ b/NUnit.MSBuild/NUnit.MSBuild.targets
@@ -19,7 +19,7 @@ Copyright (c) Ace Olszowka 2020. All rights reserved.
   <Target
     Name="NUnitExecuteTests"
     AfterTargets="Build"
-    Condition="$(RunTests) != ''"
+    Condition="$(RunTests) != '' And $(RunTests)"
     Inputs="$(TargetPath)"
     Outputs="$(NUnitResultFileName)">
 


### PR DESCRIPTION
The current logic will run tests when RunTests has any value, not just a true value. This PR seeks to correct that behavior.